### PR TITLE
check cache should be before accessing the process.env

### DIFF
--- a/api-gateway/src/helpers/accessEnv.js
+++ b/api-gateway/src/helpers/accessEnv.js
@@ -5,12 +5,12 @@
 const cache = {};
 
 const accessEnv = (key, defaultValue) => {
+  if (cache[key]) return cache[key];
+
   if (!(key in process.env)) {
     if (defaultValue) return defaultValue;
-    throw new Error(`${key} not found in process.env!`);
+    throw new Error(`${key} not found in process.env! and default value was not set`);
   }
-
-  if (cache[key]) return cache[key];
 
   cache[key] = process.env[key];
 

--- a/api-gateway/src/helpers/accessEnv.js
+++ b/api-gateway/src/helpers/accessEnv.js
@@ -14,7 +14,7 @@ const accessEnv = (key, defaultValue) => {
 
   cache[key] = process.env[key];
 
-  return process.env[key];
+  return cache[key];
 };
 
 export default accessEnv;

--- a/listings-service/src/helpers/accessEnv.js
+++ b/listings-service/src/helpers/accessEnv.js
@@ -5,12 +5,12 @@
 const cache = {};
 
 const accessEnv = (key, defaultValue) => {
+  if (cache[key]) return cache[key];
+
   if (!(key in process.env)) {
     if (defaultValue) return defaultValue;
-    throw new Error(`${key} not found in process.env!`);
+    throw new Error(`${key} not found in process.env! and default value was not set`);
   }
-
-  if (cache[key]) return cache[key];
 
   cache[key] = process.env[key];
 

--- a/listings-service/src/helpers/accessEnv.js
+++ b/listings-service/src/helpers/accessEnv.js
@@ -14,7 +14,7 @@ const accessEnv = (key, defaultValue) => {
 
   cache[key] = process.env[key];
 
-  return process.env[key];
+  return cache[key];
 };
 
 export default accessEnv;

--- a/node-deploy/src/helpers/accessEnv.js
+++ b/node-deploy/src/helpers/accessEnv.js
@@ -10,7 +10,7 @@ const accessEnv = (key, defaultValue) => {
 
   cache[key] = process.env[key];
 
-  return process.env[key];
+  return cache[key];
 };
 
 module.exports = accessEnv;

--- a/node-deploy/src/helpers/accessEnv.js
+++ b/node-deploy/src/helpers/accessEnv.js
@@ -1,12 +1,12 @@
 const cache = {};
 
 const accessEnv = (key, defaultValue) => {
+  if (cache[key]) return cache[key];
+  
   if (!(key in process.env)) {
     if (defaultValue) return defaultValue;
-    throw new Error(`${key} not found in process.env!`);
+    throw new Error(`${key} not found in process.env! and default value was not set`);
   }
-
-  if (cache[key]) return cache[key];
 
   cache[key] = process.env[key];
 

--- a/users-service/src/helpers/accessEnv.js
+++ b/users-service/src/helpers/accessEnv.js
@@ -5,12 +5,12 @@
 const cache = {};
 
 const accessEnv = (key, defaultValue) => {
+  if (cache[key]) return cache[key];
+  
   if (!(key in process.env)) {
     if (defaultValue) return defaultValue;
-    throw new Error(`${key} not found in process.env!`);
+    throw new Error(`${key} not found in process.env! and default value was not set`);
   }
-
-  if (cache[key]) return cache[key];
 
   cache[key] = process.env[key];
 

--- a/users-service/src/helpers/accessEnv.js
+++ b/users-service/src/helpers/accessEnv.js
@@ -14,7 +14,7 @@ const accessEnv = (key, defaultValue) => {
 
   cache[key] = process.env[key];
 
-  return process.env[key];
+  return cache[key];
 };
 
 export default accessEnv;


### PR DESCRIPTION
Thank you for such an amazing tutorial!
I have a feeling that your accessEnv helper needs a little tweak. Since the main intention of this helper is to reduce the amount of accesses to process.env, you should check whether `key` is in `process.env` after confirming that the key is not already cached.

That seems like a proper logic.
> check if key is cached 
> if not cached, check whether key is in process.env
> if not found, check default value
> if no default value, throw an error